### PR TITLE
Fix userId attachment in authMiddleware

### DIFF
--- a/event_management_system/src/lib/authMiddleware.js
+++ b/event_management_system/src/lib/authMiddleware.js
@@ -11,7 +11,8 @@ export const authMiddleware = (handler) => (req, res) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = decoded.user;
+    // Attach the userId from the token payload for downstream handlers
+    req.userId = decoded.userId;
     return handler(req, res);
   } catch (error) {
     res


### PR DESCRIPTION
## Summary
- fix authMiddleware to attach `req.userId` from verified token payload

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be8b91350832da28c8bc5592fdf12